### PR TITLE
Add options to configure connection/socket timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,22 @@ $KAFKA_HOME/bin/connect-standalone $KAFKA_HOME/config/connect-standalone.propert
 
 ## Sink Connector Properties
 
-| Name                                 | Description                                                                                                               | Type    | Default        | Importance |
-|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-------- |--------------- |------------|
-| infinispan.connection.hosts          | List of comma separated Infinispan hosts                                                                                  | string  | localhost      | high       |
-| infinispan.connection.hotrod.port    | Infinispan Hot Rod port                                                                                                   | int     | 11222          | high       |
-| infinispan.connection.cache.name     | Infinispan Cache name of use                                                                                              | String  | default        | medium     |
-| infinispan.use.proto                 | If true, the Remote Cache Manager will be configured to use protostream schemas                                           | boolean | false          | medium     |
-| infinispan.proto.marshaller.class    | If infinispan.use.proto is true, this option has to contain an annotated protostream class to be used                     | Class   | String.class   | medium     |
-| infinispan.cache.force.return.values | By default, previously existing values for Map operations are not returned, if set to true the values will be returned    | boolean | false          | low        |
-| infinispan.use.lifespan              | If true, the Remote Cache Manager will be configured to use Lifespan associated to cache entries                          | boolean | false          | low        |
-| infinispan.use.maxidle               | If true, the Remote Cache Manager will be configured to use Max idle value associated to cache entries                    | boolean | false          | low        |
-| infinispan.cache.lifespan.entry      | If infinispan.use.lifespan is true, this option has to the lifespan associated with the entries to be stored (in seconds) | long    | false          | low        |
-| infinispan.cache.maxidle.entry       | If infinispan.use.maxidle is true, this option has to the max idle associated with the entries to be stored (in seconds)  | long    | false          | low        |
-| infinispan.hotrod.protocol.version   | The infinispan hotrod client protocol version to use                                                                      | int     | default        | low        |
+| Name                                 | Description                                                                                                               | Type    | Default                  | Importance |
+|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-------- |------------------------- |------------|
+| infinispan.connection.hosts          | List of comma separated Infinispan hosts                                                                                  | string  | localhost                | high       |
+| infinispan.connection.hotrod.port    | Infinispan Hot Rod port                                                                                                   | int     | 11222                    | high       |
+| infinispan.connection.cache.name     | Infinispan Cache name of use                                                                                              | String  | default                  | medium     |
+| infinispan.use.proto                 | If true, the Remote Cache Manager will be configured to use protostream schemas                                           | boolean | false                    | medium     |
+| infinispan.proto.marshaller.class    | If infinispan.use.proto is true, this option has to contain an annotated protostream class to be used                     | Class   | String.class             | medium     |
+| infinispan.cache.force.return.values | By default, previously existing values for Map operations are not returned, if set to true the values will be returned    | boolean | false                    | low        |
+| infinispan.use.lifespan              | If true, the Remote Cache Manager will be configured to use Lifespan associated to cache entries                          | boolean | false                    | low        |
+| infinispan.use.maxidle               | If true, the Remote Cache Manager will be configured to use Max idle value associated to cache entries                    | boolean | false                    | low        |
+| infinispan.cache.lifespan.entry      | If infinispan.use.lifespan is true, this option has to the lifespan associated with the entries to be stored (in seconds) | long    | false                    | low        |
+| infinispan.cache.maxidle.entry       | If infinispan.use.maxidle is true, this option has to the max idle associated with the entries to be stored (in seconds)  | long    | false                    | low        |
+| infinispan.hotrod.protocol.version   | The infinispan hotrod client protocol version to use                                                                      | String  | DEFAULT_PROTOCOL_VERSION | low        |
+| infinispan.hotrod.socket_timeout     | The infinispan hotrod client timeout for socket read/writes                                                               | int     | 5000                     | low        |
+| infinispan.hotrod.connect_timeout    | The infinispan hotrod client timeout for connections                                                                      | int     | 5000                     | low        |
+| infinispan.hotrod.max_retries        | The infinispan hotrod client maximum number of operation retries                                                          | int     | 5                        | low        |
 
 ## Configuration example
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,13 +95,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-            <plugins>
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -143,7 +142,7 @@
                     </execution>
                 </executions>
             </plugin>
-            </plugins>
+        </plugins>
     </build>
 
     <profiles>

--- a/core/src/main/java/org/infinispan/kafka/InfinispanSinkConnectorConfig.java
+++ b/core/src/main/java/org/infinispan/kafka/InfinispanSinkConnectorConfig.java
@@ -38,6 +38,9 @@ public class InfinispanSinkConnectorConfig extends AbstractConfig {
    public static final long INFINISPAN_LIFESPAN_ENTRY_DEFAULT = 0L;
    public static final long INFINISPAN_MAX_IDLE_ENTRY_DEFAULT = 0L;
    public static final String INFINISPAN_HOTROD_PROTOCOL_VERSION_DEFAULT = ProtocolVersion.DEFAULT_PROTOCOL_VERSION.name();
+   public static final int INFINISPAN_HOTROD_SOCKET_TIMEOUT_DEFAULT = 5000;
+   public static final int INFINISPAN_HOTROD_CONNECT_TIMEOUT_DEFAULT = 5000;
+   public static final int INFINISPAN_HOTROD_MAX_RETRIES_DEFAULT = 5;
 
    public static final String INFINISPAN_CONNECTION_HOSTS_CONF = "infinispan.connection.hosts";
    private static final String INFINISPAN_CONNECTION_HOSTS_DOC = "The infinispan connection hosts";
@@ -72,6 +75,15 @@ public class InfinispanSinkConnectorConfig extends AbstractConfig {
    public static final String INFINISPAN_HOTROD_PROTOCOL_VERSION_CONF = "infinispan.hotrod.protocol.version";
    private static final String INFINISPAN_HOTROD_PROTOCOL_VERSION_DOC = "The infinispan hotrod client protocol version to use";
 
+   public static final String INFINISPAN_HOTROD_SOCKET_TIMEOUT_CONF = "infinispan.hotrod.socket_timeout";
+   private static final String INFINISPAN_HOTROD_SOCKET_TIMEOUT_DOC = "The infinispan hotrod client timeout for socket read/writes";
+
+   public static final String INFINISPAN_HOTROD_CONNECT_TIMEOUT_CONF = "infinispan.hotrod.connect_timeout";
+   private static final String INFINISPAN_HOTROD_CONNECT_TIMEOUT_DOC = "The infinispan hotrod client timeout for connections";
+
+   public static final String INFINISPAN_HOTROD_MAX_RETRIES_CONF = "infinispan.hotrod.max_retries";
+   private static final String INFINISPAN_HOTROD_MAX_RETRIES_DOC = "The infinispan hotrod client maximum number of operation retries";
+
    public InfinispanSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
       super(config, parsedConfig);
    }
@@ -104,6 +116,12 @@ public class InfinispanSinkConnectorConfig extends AbstractConfig {
             .define(INFINISPAN_MAX_IDLE_ENTRY_CONF, Type.LONG, INFINISPAN_MAX_IDLE_ENTRY_DEFAULT,
                     Importance.LOW, INFINISPAN_MAX_IDLE_ENTRY_DOC)
             .define(INFINISPAN_HOTROD_PROTOCOL_VERSION_CONF, Type.STRING, INFINISPAN_HOTROD_PROTOCOL_VERSION_DEFAULT,
-                    Importance.LOW, INFINISPAN_HOTROD_PROTOCOL_VERSION_DOC);
+                    Importance.LOW, INFINISPAN_HOTROD_PROTOCOL_VERSION_DOC)
+            .define(INFINISPAN_HOTROD_SOCKET_TIMEOUT_CONF, Type.INT, INFINISPAN_HOTROD_SOCKET_TIMEOUT_DEFAULT,
+                    Importance.LOW, INFINISPAN_HOTROD_SOCKET_TIMEOUT_DOC)
+            .define(INFINISPAN_HOTROD_CONNECT_TIMEOUT_CONF, Type.INT, INFINISPAN_HOTROD_CONNECT_TIMEOUT_DEFAULT,
+                    Importance.LOW, INFINISPAN_HOTROD_CONNECT_TIMEOUT_DOC)
+            .define(INFINISPAN_HOTROD_MAX_RETRIES_CONF, Type.INT, INFINISPAN_HOTROD_MAX_RETRIES_DEFAULT,
+                    Importance.LOW, INFINISPAN_HOTROD_MAX_RETRIES_DOC);
    }
 }

--- a/core/src/main/java/org/infinispan/kafka/InfinispanSinkTask.java
+++ b/core/src/main/java/org/infinispan/kafka/InfinispanSinkTask.java
@@ -89,6 +89,9 @@ public class InfinispanSinkTask extends SinkTask {
       builder.addServer()
             .host(config.getString(InfinispanSinkConnectorConfig.INFINISPAN_CONNECTION_HOSTS_CONF))
             .port(config.getInt(InfinispanSinkConnectorConfig.INFINISPAN_CONNECTION_HOTROD_PORT_CONF))
+            .socketTimeout(config.getInt(InfinispanSinkConnectorConfig.INFINISPAN_HOTROD_SOCKET_TIMEOUT_CONF))
+            .connectionTimeout(config.getInt(InfinispanSinkConnectorConfig.INFINISPAN_HOTROD_CONNECT_TIMEOUT_CONF))
+            .maxRetries(config.getInt(InfinispanSinkConnectorConfig.INFINISPAN_HOTROD_MAX_RETRIES_CONF))
             .version(ProtocolVersion.valueOf(version));
       boolean useProto = config.getBoolean(InfinispanSinkConnectorConfig.INFINISPAN_USE_PROTO_CONF);
       if (useProto) {


### PR DESCRIPTION
This prevents SocketTimeoutException error when HotRod Java client trying to reconnect on Infinispan server. Error was occurs mostly on OpenShift/Kubernetes installation this component on KafkaConnectS2I image.
I will provide instruction how to run this component on OpenShift/Kubernetes with Strimzi